### PR TITLE
fix build script for doc generation with minimal dependencies

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -2,6 +2,7 @@ name: documentation
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build-doc:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,8 @@ option(BUILD_BENCHMARK "Build benchmark" OFF)
 # Define executable name for different platforms
 set(DOUKA_EXECUTABLE_NAME "${PROJECT_NAME}")
 
-# CMake Local Module Imports
-include(${CMAKE_SOURCE_DIR}/cmake/clang_format.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/cppcheck.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/dependencies.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/filesystem.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/git-version.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/install.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/status.cmake)
-
 # Get git tag as PROJECT_VERSION
+include(${CMAKE_SOURCE_DIR}/cmake/git-version.cmake)
 get_git_version()
 
 # Build Documentation
@@ -37,6 +29,14 @@ if(BUILD_DOC)
   build_doc()
   return()
 endif(BUILD_DOC)
+
+# CMake Local Module Imports
+include(${CMAKE_SOURCE_DIR}/cmake/clang_format.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/cppcheck.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/dependencies.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/filesystem.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/install.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/status.cmake)
 
 # Interface
 set(PLUGIN_INTERFACE_PUBLIC_HEADERES


### PR DESCRIPTION
This pull request includes updates to improve workflow flexibility and reorganize the CMake configuration. The most significant changes involve adding manual trigger support for workflows and enabling documentation build with minimal dependencies.

### Workflow improvements:
* [`.github/workflows/doc.yaml`](diffhunk://#diff-37b37e811fea3a6d071b994d25f43967aefb1392178eb0bef71ede19ec1ba681R5): Added `workflow_dispatch` to enable manual triggering of the documentation workflow.

### CMake configuration updates:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL22-R23): Reorganized CMake module imports by moving non-essential modules (`clang_format.cmake`, `cppcheck.cmake`, `dependencies.cmake`, `filesystem.cmake`, `install.cmake`, `status.cmake`) to a conditional block executed only if `BUILD_DOC` is enabled, improving modularity and reducing unnecessary imports during builds without documentation. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL22-R23) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR33-R40)