### PR TITLE
fix installation instruction

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -148,7 +148,7 @@ After building the project, you can install the binaries by typing the following
 
       .. code-block:: bash
 
-        cmake --install build
+        cmake --install build/release
 
         # You will see the version of the installed binaries.
         douka --version
@@ -160,7 +160,7 @@ After building the project, you can install the binaries by typing the following
 
       .. code-block:: bash
 
-        cmake --install build
+        cmake --install build/release
 
         # You will see the version of the installed binaries.
         douka --version
@@ -172,7 +172,7 @@ After building the project, you can install the binaries by typing the following
 
       .. code-block:: bash
 
-        cmake --install build
+        cmake --install build/release
 
         # You will see the version of the installed binaries.
         douka --version
@@ -184,7 +184,7 @@ After building the project, you can install the binaries by typing the following
 
       .. code-block:: bash
 
-        cmake --install build
+        cmake --install build/a64fx-release
 
       .. note::
         You will need to login to the compute node to use the installed binaries.


### PR DESCRIPTION
This pull request updates the installation instructions in the documentation to clarify the correct build directory to use when installing the binaries. The changes ensure that users run the `cmake --install` command with the appropriate subdirectory for their build type.

Documentation updates:

* Updated all installation command examples to use `cmake --install build/release` instead of `cmake --install build` for standard builds in `doc/source/installation.rst`. [[1]](diffhunk://#diff-bec81341b47d84996ded0a8b988df41fb4977906b88454f2e6922f159d5b4965L151-R151) [[2]](diffhunk://#diff-bec81341b47d84996ded0a8b988df41fb4977906b88454f2e6922f159d5b4965L163-R163) [[3]](diffhunk://#diff-bec81341b47d84996ded0a8b988df41fb4977906b88454f2e6922f159d5b4965L175-R175)
* Updated the installation command for the A64FX architecture to use `cmake --install build/a64fx-release` instead of `cmake --install build` in `doc/source/installation.rst`.